### PR TITLE
feat: add details view

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,25 @@ Este challenge es realizado con las siguientes tecnologías:
 - Se añade y configura **GraphQL** y **ApolloClient** para manejar consultas y manipular datos desde una API GraphQL
 - Se usa y configura **context api** para evitar el prop drilling y hacer uso de un estado global para los filtros
 - Se añade **just-debounce-it** para optimizar las consultas a la api y mejorar la performance
+
+## Instalación
+
+1. Clonar este repositorio
+
+```bash
+git clone https://github.com/lllariogonzalez/kimche-challenge
+```
+
+2. Entrar al directorio del proyecto e instalar dependencias
+
+```bash
+npm install
+```
+
+3. Ejecutar el proyecto en modo desarrollo
+
+```bash
+npm run dev
+```
+
+4. Abrir [http://localhost:5173/](http://localhost:5173/) en el navegador

--- a/src/assets/CloseIcon.jsx
+++ b/src/assets/CloseIcon.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types'
+
+export default function CloseIcon ({ className }) {
+  return (
+    <svg fill='none' viewBox='0 0 24 24' strokeWidth='2.5' stroke='currentColor' className={`w-6 h-6 ${className}`}>
+      <path strokeLinecap='round' strokeLinejoin='round' d='M6 18 18 6M6 6l12 12' />
+    </svg>
+  )
+}
+
+CloseIcon.propTypes = {
+  className: PropTypes.string.isRequired
+}

--- a/src/characters/custom-hooks.js
+++ b/src/characters/custom-hooks.js
@@ -1,5 +1,5 @@
 import { useLazyQuery } from '@apollo/client'
-import { GET_CHARACTERS } from './graphql-queries'
+import { GET_CHARACTER, GET_CHARACTERS } from './graphql-queries'
 import { useCallback, useContext, useEffect } from 'react'
 import { FiltersContext } from '../context/FiltersContext'
 import debounce from 'just-debounce-it'
@@ -22,4 +22,10 @@ export function useCharacters () {
   }, [debounceGetCharacters, filters])
 
   return { characters, error, loading }
+}
+
+export function useCharacter () {
+  const [getCharacter, { data, error, loading }] = useLazyQuery(GET_CHARACTER)
+  const character = data?.character
+  return [getCharacter, { character, error, loading }]
 }

--- a/src/characters/graphql-queries.js
+++ b/src/characters/graphql-queries.js
@@ -17,3 +17,24 @@ query($page: Int, $name: String, $status: String, $species: String, $gender: Str
   }
 }
 `
+
+export const GET_CHARACTER = gql`
+query Character($id: ID!){
+  character(id: $id){
+  id
+  name
+  image
+  status
+  gender
+  species
+  type
+  location {
+    name
+  }
+  origin {
+    name
+    dimension
+  }
+}
+}
+`

--- a/src/components/CharacterCard.jsx
+++ b/src/components/CharacterCard.jsx
@@ -1,15 +1,31 @@
 import PropTypes from 'prop-types'
+import CharacterDetails from './CharacterDetails'
+import { useState } from 'react'
+import Modal from './Modal'
 
-export default function CharacterCard ({ name, image }) {
+export default function CharacterCard ({ id, name, image }) {
+  const [showDetails, setShowDetails] = useState(false)
+
+  const handleShowDetails = () => {
+    setShowDetails(!showDetails)
+  }
+
   return (
-    <article className='card relative rounded-xl overflow-hidden hover:scale-105 hover:-translate-y-3 transition-all ease-in-out duration-300 cursor-pointer'>
-      <img className='w-full rounded-lg' src={image} alt={name} />
-      <span className='absolute text-white -translate-x-2/4 font-bold left-2/4 bottom-1 text-center text-pretty text-xs md:text-sm shadow-2xl'>{name}</span>
-    </article>
+    <>
+      <article onClick={handleShowDetails} className='card relative rounded-xl overflow-hidden hover:scale-105 hover:-translate-y-3 transition-all ease-in-out duration-300 cursor-pointer'>
+        <img className='w-full rounded-lg' src={image} alt={name} />
+        <span className='absolute text-white -translate-x-2/4 font-bold left-2/4 bottom-1 text-center text-pretty text-xs md:text-sm shadow-2xl'>{name}</span>
+      </article>
+      {showDetails &&
+        <Modal onClick={handleShowDetails}>
+          <CharacterDetails id={id} onClick={handleShowDetails} />
+        </Modal>}
+    </>
   )
 }
 
 CharacterCard.propTypes = {
   name: PropTypes.string.isRequired,
-  image: PropTypes.string.isRequired
+  image: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired
 }

--- a/src/components/CharacterDetails.jsx
+++ b/src/components/CharacterDetails.jsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { useCharacter } from '../characters/custom-hooks'
+import Loader from './Loader'
+import Error from './Error'
+import CloseIcon from '../assets/CloseIcon'
+
+export default function CharacterDetails ({ id, onClick }) {
+  const [getCharacter, { character, error, loading }] = useCharacter()
+
+  const handleClick = (event) => {
+    event.stopPropagation()
+  }
+
+  useEffect(() => {
+    getCharacter({ variables: { id } })
+  }, [getCharacter, id])
+
+  return (
+    <>
+      {loading && <Loader />}
+      {error && <Error>{error.message}</Error>}
+      {character &&
+        <div className='relative'>
+          <CloseIcon
+            onClick={onClick}
+            className='absolute bg-white rounded-full text-zinc-800 top-7 right-7 md:right-5 md:top-5 p-1 w-7 h-7 cursor-pointer logo hover:scale-105 transition-transform ease-in-out z-20'
+          />
+          <div onClick={handleClick} className='flex flex-col justify-center items-center md:flex-row m-5 md:m-0 bg-black rounded-xl overflow-hidden'>
+            <img className='rounded-xl' width={300} height={300} src={character.image} alt={character.name} />
+            <div className='flex flex-col gap-4 py-5 px-2 w-[300px] md:w-fit md:px-20 text-center'>
+              <h1 className='font-bold text-3xl'>{character.name}</h1>
+              <div className='text-pretty text-base'>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Status: </strong>{character.status}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Gender: </strong>{character.gender}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Species: </strong>{character.species}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Type: </strong>{character.type}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Location: </strong>{character.location.name}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Origin: </strong>{character.origin.name}</p>
+                <p><strong className='font-bold text-lg md:text-xl text-sky-300'>Dimension: </strong>{character.origin.dimension}</p>
+              </div>
+            </div>
+          </div>
+        </div>}
+    </>
+  )
+}
+
+CharacterDetails.propTypes = {
+  id: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired
+}

--- a/src/components/Characters.jsx
+++ b/src/components/Characters.jsx
@@ -13,7 +13,13 @@ export default function Characters () {
       {characters && characters.length > 0
         ? (
           <section className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4'>
-            {characters.map(character => <CharacterCard key={character.id} name={character.name} image={character.image} />)}
+            {characters.map(character =>
+              <CharacterCard
+                key={character.id}
+                id={character.id}
+                name={character.name}
+                image={character.image}
+              />)}
           </section>
           )
         : characters?.length === 0 && <Error>Character not found</Error>}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types'
+
+export default function Modal ({ children, onClick }) {
+  return (
+    <div onClick={onClick} className='fixed top-0 left-0 flex justify-center items-center w-screen h-screen bg-black bg-opacity-50 tras z-10'>
+      {children}
+    </div>
+  )
+}
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired
+}


### PR DESCRIPTION
# Add character details view

![image](https://github.com/lllariogonzalez/kimche-challenge/assets/101127703/440c49d9-2e5a-4a78-a0d3-89474a40fcff)

![image](https://github.com/lllariogonzalez/kimche-challenge/assets/101127703/bba724c3-21df-43de-8fdc-380412c9c7aa)

- Implemented character details view functionality, allowing users to view additional information about a character by clicking on a result in the character list.
- A reusable modal component is added to display the details view.
- A Graphql query is added along with a custom hook to make the request with the character id.
- The installation guide is added to the redme
